### PR TITLE
Настройка карусели

### DIFF
--- a/css/freelancer.css
+++ b/css/freelancer.css
@@ -484,7 +484,7 @@ footer .footer-below {
     overflow-y: hidden;
 }
 .carousel-inner {
-    overflow: inherit;
+    overflow: hidden;
     position: relative;
     padding: 0px;
     width: 100%;


### PR DESCRIPTION
Изменил значение свойства overflow с «inherin» на «hidden» селектору
.carousel-inner для того чтобы при прокрутки элементы не выходили за
границы родителя.